### PR TITLE
Add a non equation number to example

### DIFF
--- a/content/docs/01-features/04-counting-systems/07-math-equations.md
+++ b/content/docs/01-features/04-counting-systems/07-math-equations.md
@@ -27,6 +27,7 @@ import {
     {"."}
   </Message>
   <Message>11*9</Message>
+  <Message>100</Message>
 </Discord>
 ```
 


### PR DESCRIPTION
Add a non-equation number to example in order to clarify that using numbers without equations is not prohibited.