### PR TITLE
Remove exponents from  example

### DIFF
--- a/content/docs/01-features/04-counting-systems/07-math-equations.md
+++ b/content/docs/01-features/04-counting-systems/07-math-equations.md
@@ -14,8 +14,8 @@ import {
 <Discord>
   <Message>27*3+14</Message>
   <Message>16*6</Message>
-  <Message>9^2+2^4</Message>
-  <Message>7^2*2</Message>
+  <Message>81+16</Message>
+  <Message>7*7*2</Message>
   <Message profile="countr" ephemeral>
     <Command slot="reply" command="/count" />
     {"📊 Current count for "}


### PR DESCRIPTION
Remove exponents from example to match actual function within bot.