### PR TITLE
Temporary workaround for `stat.count` being undefined

### DIFF
--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -54,7 +54,7 @@ export default class Stats extends React.Component<Record<string, never>, { stat
         {stats
           .map((stat, index) => <div className={styles["stat"]} key={index}>
             <h2>{stat.title}{stat.link ? <Link to={stat.link}>*</Link> : ""}</h2>
-            <p>{stat.count.toLocaleString("en-US")}</p>
+            <p>{stat.count?.toLocaleString("en-US")}</p>
             {/* eslint-disable-next-line @stylistic/jsx/jsx-closing-tag-location */}
           </div>)}
       </div>


### PR DESCRIPTION
`stat.count` may be undefined in some cases